### PR TITLE
Added player's choice for playing pawn

### DIFF
--- a/examples/player_list_evaluator.py
+++ b/examples/player_list_evaluator.py
@@ -25,6 +25,9 @@ tester.verbose_level = 0  # 0: no output, 1: Each game results, 2: Each move res
 nb_games = 1000
 results = {}  # We will count the number of victories for each player
 
+# Initialize global victory type evaluator
+dic_global_win_lose_type = {}
+
 # Match all combinations of players
 for i, player1_class in enumerate(players_classes):
     # Get the name of the player
@@ -39,6 +42,9 @@ for i, player1_class in enumerate(players_classes):
         p1 = player1_class(1)
         p2 = player2_class(2)
 
+        # Initialize victory type evaluator dic
+        dic_win_lose_type = {p1.name(): {}, p2.name(): {}}
+
         # Get the name of the player 2
         player2_name = p2.name()
         results[player1_name][player2_name] = 0
@@ -46,9 +52,12 @@ for i, player1_class in enumerate(players_classes):
         print(f"\n\nPlaying {player1_name} vs {player2_name}:")
 
         # Play 100 games
-        victories_number = tester.play_1v1(p1, p2, nb_games=nb_games)
+        victories_number,  dic_global_win_lose_type[f"{p1.name()}vs{p2.name()}"] = \
+            tester.play_1v1(p1, p2, nb_games=nb_games, dic_win_lose_type=dic_win_lose_type)
+
         results[player1_name][player2_name] = victories_number[player1_name]
 
+print(f"dic_global_win_lose_type = \n{dic_global_win_lose_type}")
 
 print()
 print("Results:")

--- a/examples/player_list_evaluator.py
+++ b/examples/player_list_evaluator.py
@@ -11,9 +11,10 @@ from santorinai.player_examples.basic_player import BasicPlayer
 # It will display a table with the results of each player against each other player.
 
 players_classes = [
+    BasicPlayer,
     RandomPlayer,
     FirstChoicePlayer,
-    BasicPlayer,
+
 ]
 
 # Init the tester
@@ -27,7 +28,7 @@ results = {}  # We will count the number of victories for each player
 # Match all combinations of players
 for i, player1_class in enumerate(players_classes):
     # Get the name of the player
-    player1_name = player1_class().name()
+    player1_name = player1_class(i).name()
     results[player1_name] = {}
 
     for j, player2_class in enumerate(players_classes):
@@ -35,8 +36,8 @@ for i, player1_class in enumerate(players_classes):
             continue
 
         # Init the players
-        p1 = player1_class()
-        p2 = player2_class()
+        p1 = player1_class(1)
+        p2 = player2_class(2)
 
         # Get the name of the player 2
         player2_name = p2.name()

--- a/examples/random_players_match.py
+++ b/examples/random_players_match.py
@@ -4,6 +4,7 @@ sys.path.append('..')
 from santorinai.tester import Tester
 from santorinai.player_examples.random_player import RandomPlayer
 from santorinai.player_examples.first_choice_player import FirstChoicePlayer
+from santorinai.player_examples.basic_player import BasicPlayer
 
 # Init the tester
 tester = Tester()
@@ -12,8 +13,9 @@ tester.delay_between_moves = 0.5  # Delay between each move in seconds
 tester.display_board = True  # Display a graphical view of the board in a window
 
 # Init the players
-my_player = FirstChoicePlayer()
-random_payer = RandomPlayer()
+my_player = FirstChoicePlayer(1)
+basic_player = BasicPlayer(1)
+random_payer = RandomPlayer(2)
 
 # Play 100 games
-tester.play_1v1(my_player, random_payer, nb_games=100)
+tester.play_1v1(basic_player, random_payer, nb_games=100)

--- a/santorinai/board.py
+++ b/santorinai/board.py
@@ -70,6 +70,7 @@ class Board:
         self.pawn_turn = 1
         self.winner_player_number = None
         self.turn_number = 1
+        self.player_turn = 1
 
     def is_move_possible(
         self, start_pos: Tuple[int, int], end_pos: Tuple[int, int]
@@ -212,6 +213,20 @@ class Board:
         """
         return self.pawns[self.pawn_turn - 1]
 
+    def get_player_pawns(self, player_number: int) -> List[Pawn]:
+        """
+        Gets the pawn of the current player.
+
+        Returns:
+            Pawn: The pawn of the current player.
+        """
+        l_pawns = []
+        for pawn in self.pawns:
+            if pawn.player_number == player_number:
+                l_pawns.append(pawn)
+
+        return l_pawns
+
     def get_possible_movement_positions(self, pawn: Pawn) -> List[Tuple[int, int]]:
         """
         Gets all the possible moves for a given pawn.
@@ -347,10 +362,10 @@ class Board:
         return True, "The pawn was placed."
 
     def play_move(
-        self, move_position: Tuple[int, int], build_position: Tuple[int, int]
+        self, pawn_number:int, move_position: Tuple[int, int], build_position: Tuple[int, int]
     ) -> Tuple[bool, str]:
         """
-        Plays a move on the board with the current playing pawn.
+        Plays a move on the board with the chosen playing pawn.
 
         Args:
             move_position (tuple): The position (x, y) to move the pawn to.
@@ -360,12 +375,15 @@ class Board:
             bool: True if the move was played, False otherwise.
             str: A string describing why the move was not played.
         """
+        # Get the moving pawn
+        pawn = self.pawns[pawn_number - 1]
+
         # Check if the game is over
         if self.is_game_over():
             return False, "The game is over."
 
         # Get the pawn of the current player
-        pawn = self.get_playing_pawn()
+        # pawn = self.get_playing_pawn()
 
         # Check if the pawn has been placed
         if pawn.pos[0] is None or pawn.pos[1] is None:
@@ -492,8 +510,11 @@ class Board:
         Changes the turn.
         """
         self.pawn_turn += 1
-        if self.pawn_turn > self.nb_pawns:
-            self.pawn_turn = 1
+        # if self.pawn_turn > self.nb_pawns:
+        #     self.pawn_turn = 1
+        self.player_turn += 1
+        if self.player_turn > self.nb_players:
+            self.player_turn = 1
 
         self.turn_number += 1
 

--- a/santorinai/player.py
+++ b/santorinai/player.py
@@ -9,6 +9,9 @@ class Player:
     """
     A player of Santorini, has a name and can play a move given a board
     """
+    def __init__(self, player_number: int, log_level=0) -> None:
+        self.log_level = log_level
+        self.player_number = player_number
 
     @abstractmethod
     def name(self):
@@ -32,12 +35,11 @@ class Player:
 
     @abstractmethod
     def play_move(
-        self, board: Board, pawn: Pawn
-    ) -> Tuple[Tuple[int, int], Tuple[int, int]]:
+        self, board: Board
+    ) -> Tuple[int, Tuple[int, int], Tuple[int, int]]:
         """
-        Play a move given a board
+        Choose a pawn and play a move given a board
         :param board: the board
-        :param pawn: the pawn that needs to be moved and that needs to build
         :return: two positions of the form (x1, y1), (x2, y2)
 
         The first coordinate corresponds to the new position of the pawn

--- a/santorinai/player_examples/basic_player.py
+++ b/santorinai/player_examples/basic_player.py
@@ -71,7 +71,7 @@ class BasicPlayer(Player):
         available_pawns = []
         best_spot = None
         best_spot_pawn_idx = None
-        best_spot_level = 0
+        best_spot_level = -2
 
         # Iterate over available pawns
         for idx, pawn in enumerate(board.get_player_pawns(self.player_number)):
@@ -93,7 +93,7 @@ class BasicPlayer(Player):
 
                 # Check if possible to go up
                 pos_level = board.board[pos[0]][pos[1]]
-                if pos_level <= current_level + 1 and pos_level > best_spot_level:
+                if pos_level <= current_level + 1 and pos_level > best_spot_level + current_level:
                     # We can go up
                     best_spot = pos
                     best_spot_pawn_idx = idx

--- a/santorinai/player_examples/basic_player.py
+++ b/santorinai/player_examples/basic_player.py
@@ -75,7 +75,6 @@ class BasicPlayer(Player):
 
         # Iterate over available pawns
         for idx, pawn in enumerate(board.get_player_pawns(self.player_number)):
-            # Simulate the move (Need to use pawn copy since returned pawn will be moved)
             if pawn.pos[0] is None or pawn.pos[1] is None:
                 # Pawn is not placed yet
                 raise Exception("Pawn is not placed yet")
@@ -117,16 +116,24 @@ class BasicPlayer(Player):
         if best_spot:
             if self.log_level:
                 print("Moving up")
-            pawn.move(best_spot)
-            build_positions = board.get_possible_building_positions(pawn)
-            if not build_positions:
-                pass
-            return available_pawns[best_spot_pawn_idx].number, best_spot, choice(build_positions)
+            best_pawn = available_pawns[best_spot_pawn_idx]
+            best_pawn.move(best_spot)
+            available_build_pos = board.get_possible_building_positions(best_pawn)
+            if available_build_pos:
+                build_choice = choice(available_build_pos)
+            else:
+                build_choice = None
+
+            return available_pawns[best_spot_pawn_idx].number, best_spot, build_choice
 
         if self.log_level:
             print("Random move")
 
         # play randomly
         pawn = choice(board.get_player_pawns(self.player_number))
-        t_move_build = choice(board.get_possible_movement_and_building_positions(pawn))
+        t_move_build = board.get_possible_movement_and_building_positions(pawn)
+        if t_move_build:
+            t_move_build = choice(t_move_build)
+        else:
+            t_move_build = (None,None)
         return (pawn.number,) + t_move_build

--- a/santorinai/player_examples/first_choice_player.py
+++ b/santorinai/player_examples/first_choice_player.py
@@ -7,6 +7,8 @@ class FirstChoicePlayer(Player):
     """
     A player that places his pawns and moves them at the first possible position
     """
+    def __init__(self, player_number, log_level=0) -> None:
+        super().__init__(player_number, log_level)
 
     def name(self):
         return "Firsty First"
@@ -16,16 +18,20 @@ class FirstChoicePlayer(Player):
         my_choice = available_positions[0]
         return my_choice
 
-    def play_move(self, board: Board, pawn: Pawn):
+    def play_move(self, board: Board):
+        # Choose always first pawn
+        l_pawns = board.get_player_pawns(self.player_number)
+        pawn = l_pawns[0]
+
         # Get movement positions
         available_move_positions = board.get_possible_movement_positions(pawn)
         if len(available_move_positions) == 0:
             # The pawn cannot move
-            return None, None
+            return pawn.number, None, None
 
         my_move_choice = available_move_positions[0]
 
-        # Simulate the move (this will not impact the actual board)
+        # Simulate the move (Need to use pawn copy since returned pawn will be moved)
         pawn.move(my_move_choice)
 
         # Get construction positions
@@ -37,4 +43,4 @@ class FirstChoicePlayer(Player):
         # Their is always at least one position available
         my_build_choice = available_build_positions[0]
 
-        return my_move_choice, my_build_choice
+        return pawn.number, my_move_choice, my_build_choice

--- a/santorinai/player_examples/random_player.py
+++ b/santorinai/player_examples/random_player.py
@@ -1,5 +1,4 @@
 from santorinai.player import Player
-
 from random import choice
 
 
@@ -7,6 +6,8 @@ class RandomPlayer(Player):
     """
     A player that places his pawns and moves them randomly
     """
+    def __init__(self, player_number, log_level=0) -> None:
+        super().__init__(player_number, log_level)
 
     def name(self):
         return "Randy Random"
@@ -16,20 +17,24 @@ class RandomPlayer(Player):
         my_choice = choice(available_positions)
         return my_choice
 
-    def play_move(self, board, pawn):
+    def play_move(self, board):
+        # Choose pawn randomly
+        l_pawns = board.get_player_pawns(self.player_number)
+        pawn = choice(l_pawns)
+
         # Get movement positions
         available_positions = board.get_possible_movement_positions(pawn)
         if len(available_positions) == 0:
             # The pawn cannot move
-            return None, None
+            return pawn.number, None, None
 
         my_move_choice = choice(available_positions)
 
-        # Simulate the move
+        # Simulate the move (Need to use pawn copy since returned pawn will be moved)
         pawn.move(my_move_choice)
 
         # Get construction positions for the new position
         available_positions = board.get_possible_building_positions(pawn)
         my_build_choice = choice(available_positions)
 
-        return my_move_choice, my_build_choice
+        return pawn.number, my_move_choice, my_build_choice

--- a/santorinai/tester.py
+++ b/santorinai/tester.py
@@ -27,7 +27,7 @@ class Tester:
         if self.verbose_level >= verbose_level:
             print(message)
 
-    def play_1v1(self, player1: Player, player2: Player, nb_games: int = 1):
+    def play_1v1(self, player1: Player, player2: Player, nb_games: int = 1, dic_win_lose_type=None):
         """
         Play a 1v1 game between player1 and player2
 
@@ -39,6 +39,10 @@ class Tester:
         NB_PAWNS = NB_PLAYERS * 2
 
         nb_victories = [0, 0]
+        # Initialize empty dic_win_lose_type in not passed
+        if not dic_win_lose_type:
+            dic_win_lose_type = {player1.name(): {},
+                                 player2.name(): {}}
 
         # Check if the players are objects of the Player class
         if player1 is None or not isinstance(player1, Player):
@@ -85,6 +89,9 @@ class Tester:
                         f"   Pawn placed at an invalid position: {reason}", 1
                     )
                     self.display_message(f"   Player {player.name()} loses")
+                    dic_win_lose_type[player.name()] = \
+                        register_new_victory_type(dic_win_lose_type[player.name()],
+                                                  f"   Pawn placed at an invalid position: {reason}")
                     nb_victories[(pawn_nb + 2) % NB_PLAYERS] += 1
                     break
 
@@ -125,6 +132,9 @@ class Tester:
                         f"   Pawn moved at an invalid position: {reason}", 1
                     )
                     self.display_message(f"   Player {current_player.name()} loses")
+                    dic_win_lose_type[current_player.name()] = \
+                        register_new_victory_type(dic_win_lose_type[current_player.name()],
+                                                  f"   Player {current_player.name()} loses")
                     nb_victories[(current_player.player_number) % NB_PLAYERS] += 1
                     break
 
@@ -146,7 +156,11 @@ class Tester:
                 self.display_message(
                     f"Player {players[winner_number - 1].name()} wins!"
                 )
-                nb_victories[winner_number - 1] += 1
+                dic_win_lose_type[players[winner_number - 1].name()] = \
+                    register_new_victory_type(dic_win_lose_type[players[winner_number - 1].name()],
+                                              f"Player {players[winner_number - 1].name()} wins!")
+
+            nb_victories[winner_number - 1] += 1
 
         # Display the results
         print("\nResults:")
@@ -168,4 +182,23 @@ class Tester:
         return {
             players[0].name(): nb_victories[0],
             players[1].name(): nb_victories[1],
-        }
+        }, dic_win_lose_type
+
+def register_new_victory_type(dic_win_lose_types, s_msg):
+    """
+    Function that registers types of winning and loosing conditions
+    and keeps track on a counter for each type of already registered
+    type
+    Args:
+        dic_win_lose_types:
+        s_msg:
+
+    Returns:
+
+    """
+    try:
+        dic_win_lose_types[s_msg] += 1
+    except KeyError:
+        dic_win_lose_types[s_msg] = 1
+
+    return dic_win_lose_types

--- a/santorinai/tester.py
+++ b/santorinai/tester.py
@@ -61,18 +61,19 @@ class Tester:
             board = Board(NB_PLAYERS)
 
             # Placement the pawns
-            for pawn_nb in range(1, NB_PAWNS + 1):
+            # for pawn_nb in range(1, NB_PAWNS + 1):
+            for pawn_nb, current_pawn in enumerate(board.pawns):
                 board_copy = board.copy()
-                current_pawn = board_copy.get_playing_pawn()
+                # current_pawn = board_copy.get_playing_pawn()
 
                 # If pawn_nb == 1, the player_nb is 0, if pawn_nb == 2, the
                 # player_nb is 1, if pawn_nb == 3, the player_nb is 0, etc.
-                player_nb = (pawn_nb - 1) % NB_PLAYERS
+                player_nb = (pawn_nb) % NB_PLAYERS
                 player = players[player_nb]
 
                 # Ask the player where to place the pawn
                 self.display_message(
-                    f"Player {player.name()} is placing pawn {pawn_nb}", 2
+                    f"Player {player.name()} is placing pawn {pawn_nb + 1}", 2
                 )
                 position_choice = player.place_pawn(board_copy, current_pawn)
 
@@ -84,7 +85,7 @@ class Tester:
                         f"   Pawn placed at an invalid position: {reason}", 1
                     )
                     self.display_message(f"   Player {player.name()} loses")
-                    nb_victories[(pawn_nb + 1) % NB_PLAYERS] += 1
+                    nb_victories[(pawn_nb + 2) % NB_PLAYERS] += 1
                     break
 
                 self.display_message(f"   Pawn placed at position {position_choice}", 2)
@@ -95,37 +96,36 @@ class Tester:
             # Play the game
             self.display_message("\nPlaying the game")
             while not board.is_game_over():
-                current_pawn = board.get_playing_pawn()
-                self.display_message(f"   Current pawn: {current_pawn}", 2)
+                current_player = players[board.player_turn - 1]
+                # current_pawn = board.get_playing_pawn()
+                # self.display_message(f"   Current pawn: {current_pawn}", 2)
 
                 # Check if the player can move
-                if len(board.get_possible_movement_positions(current_pawn)) == 0:
-                    self.display_message("   The pawn cannot move", 2)
-                    board.next_turn()
-                    # We don't ask the player to move, we just skip his turn
-                    continue
+                # if len(board.get_possible_movement_positions(current_pawn)) == 0:
+                #     self.display_message("   The pawn cannot move", 2)
+                #     board.next_turn()
+                #     # We don't ask the player to move, we just skip his turn
+                #     continue
 
                 board_copy = board.copy()
-                current_pawn_copy = board_copy.get_playing_pawn()
+                # current_pawn_copy = board_copy.get_playing_pawn()
 
                 # Ask the player where to move the pawn
-                player = players[current_pawn.player_number - 1]
+                # player = players[current_pawn.player_number - 1]
                 self.display_message(
-                    f"Player {player.name()} is moving pawn {current_pawn.number}", 2
+                    f"Player {current_player.name()} is moving a pawn", 2
                 )
-                move_choice, build_choice = player.play_move(
-                    board_copy, current_pawn_copy
-                )
+                pawn_nb, move_choice, build_choice = current_player.play_move(board_copy)
 
                 # Move the pawn
-                success, reason = board.play_move(move_choice, build_choice)
+                success, reason = board.play_move(pawn_nb, move_choice, build_choice)
 
                 if not success:
                     self.display_message(
                         f"   Pawn moved at an invalid position: {reason}", 1
                     )
-                    self.display_message(f"   Player {player.name()} loses")
-                    nb_victories[(current_pawn.player_number) % NB_PLAYERS] += 1
+                    self.display_message(f"   Player {current_player.name()} loses")
+                    nb_victories[(current_player.player_number) % NB_PLAYERS] += 1
                     break
 
                 self.display_message(


### PR DESCRIPTION
In the original version the board's pawns are iterated over each turn so players can't choose what pawn they want to use and have to alternate between the pawns. In this change set I have added the functionality that enables players to choose what pawn they want to use in addition to the move and build choices. The players now only receive the board when playing their moves (I kept the old functionality for placing the pawns) and need to return the pawn number, in addition to the move and build positions. I have adapted the existing players to play accordingly.
For your information, this is my first pull request so I'm a bit uncertain how does this process work, so any guidance and advice will be welcomed! :)